### PR TITLE
chore: sync package-lock.json version to 0.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "avdl",
-  "version": "0.1.2",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "avdl",
-      "version": "0.1.2",
+      "version": "0.3.0",
       "dependencies": {
         "@radix-ui/react-dialog": "^1.1.21",
         "@radix-ui/react-dropdown-menu": "^2.1.22",


### PR DESCRIPTION
## Overview

`package.json` is at `0.3.0` but `package-lock.json` was still pinned at `0.1.2`, so the lockfile would drift out of sync on lockfile version checks and dependency audits.

This change updates the `version` field inside `package-lock.json` (both the top-level and the root `packages[""]` entry) from `0.1.2` to `0.3.0`, keeping it in line with `package.json`.

## Validation

No dependency changes, code changes, or lockfile checksum updates were needed - this is a version-field-only alignment. Trivial diff (2 insertions, 2 deletions).